### PR TITLE
fix: heap overflow due to the getParent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 3. fix: sometimes the library cannot be loaded
 4. fix: other minor bugs
 5. add: go standard library display support
-6. add: two icons(.svg) from Goland
+6. add: two icons(.svg) from GoLand
 
 [0.2.3]
 
@@ -52,3 +52,11 @@
 4. fix: failed to get parent
 5. add: support "Reveal in Explorer View"
 6. chore: update readme
+
+[0.2.4]
+
+1. fix: heap overflow by getParents no return
+2. add: one icon(.svg) from GoLand
+3. change: the current it will start with the official extension
+4. update readme
+5. chore: more detail for package.json

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Vscode Market: https://marketplace.visualstudio.com/items?itemName=r3inbowari.go
     A: Notice that go.goroot has higher priority than system environment in order to be consistent with the official extension.
     A: 需要注意的是，为了与官方插件保持一致， "go.goroot" 的优先级高于系统环境变量.
 
+    Q: Why can't I find GoMod Explorer in VSCode?
+    Q: 为什么在 VSCode 中找不到 GoMod Explorer 这个窗口？
+
+    A: This extension depends on the official extension, please install the go extension at first.
+    A: 此扩展依赖于官方扩展，请先安装 Go 扩展。
+
 ---
 
     Q: How to navigate and reveal to the external code?

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Go Mod Explorer",
   "description": "Displays the External Library for the current go project in the Explorer.",
   "publisher": "r3inbowari",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/r3inbowari/go-mod-explorer.git"
@@ -52,7 +52,10 @@
       "explorer": [
         {
           "id": "gomod",
-          "name": "GoMod Explorer"
+          "name": "GoMod Explorer",
+          "icon": "resources/package.svg",
+          "contextualTitle": "GoMod Explorer",
+          "when": "go.showExplorer"
         }
       ]
     },
@@ -93,7 +96,18 @@
         "mac": "cmd+shift+'",
         "when": "focusedView == gomod"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Go Mod Explorer",
+      "properties": {
+        "gomod.revealEnable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable automatic Revael in Go Mod Explorer"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/resources/package.svg
+++ b/resources/package.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"> 
+ <g fill="none" fill-opacity=".8" fill-rule="evenodd"> 
+  <polygon fill="#9AA7B0" points="8.5 8.048 14.5 5.02 14.5 11.52 8.5 14.548" /> 
+  <polygon fill="#9AA7B0" points="1.5 8.048 7.5 5.02 7.5 11.52 1.5 14.548" transform="matrix(-1 0 0 1 9 0)" /> 
+  <polygon fill="#9AA7B0" points="1.9 4.2 8 1.603 14.1 4.2 8 7.228" transform="matrix(-1 0 0 1 16 0)" /> 
+ </g> 
+</svg>

--- a/src/mod-tree.ts
+++ b/src/mod-tree.ts
@@ -216,6 +216,10 @@ export class ModTree implements TreeDataProvider<ModItem>, TextDocumentContentPr
     let parentPathString = path.resolve(element.resourceUri?.fsPath, '..');
     let parentPathURI = Uri.parse(parentPathString);
 
+    if (parentName === '') {
+      return null;
+    }
+
     for (let index = 0; index < this._rootData.length; index++) {
       let ep1 = element.resourceUri?.path;
       let ep2 = this._rootData[index].resourceUri?.path;


### PR DESCRIPTION
1. fix: heap overflow by getParents no return
2. add: one icon(.svg) from GoLand
3. change: the current it will start with the official extension
4. update readme
5. chore: more detail for package.json
