### PR TITLE
discard search button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gomodexplorer",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gomodexplorer",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "chokidar": "^3.5.3",
         "open-file-explorer": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Go Mod Explorer",
   "description": "Displays the external libraries for the current go project in the Explorer.",
   "publisher": "r3inbowari",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/r3inbowari/go-mod-explorer.git"
@@ -39,8 +39,7 @@
       },
       {
         "command": "gomod.focus",
-        "title": "Focus and search",
-        "icon": "$(search-view-icon)"
+        "title": "Focus"
       },
       {
         "command": "gomod.collapse",
@@ -75,11 +74,6 @@
     },
     "menus": {
       "view/title": [
-        {
-          "command": "gomod.focus",
-          "group": "navigation",
-          "when": "view == gomod"
-        },
         {
           "command": "gomod.collapse",
           "group": "navigation",

--- a/src/modTree.ts
+++ b/src/modTree.ts
@@ -414,7 +414,7 @@ export class ModTree implements TreeDataProvider<ModItem>, TextDocumentContentPr
    * the tree view may be not collapsed. So we need to add an invisible token to the
    * front of the label content ('\r' is a good choice) in order to make collapse work.
    *
-   * We call workbench.actions.treeView.[viewID which setting on package.json views attrs].collapseAll to collapse All item
+   * We call workbench.actions.treeView.[viewID which setting on package.json views attrs].collapseAll to collapse All items
    *
    * @update 2022/06/16
    */


### PR DESCRIPTION
Since 1.70.0, vscode supports built-in search widget via `Ctrl+f` while the explorer is focused 
![image](https://user-images.githubusercontent.com/30739857/201633731-f11bfb91-4d89-4ad7-b443-6bf921f12204.png)

ref https://github.com/microsoft/vscode/pull/152481
related #5 